### PR TITLE
Add Changelog Enforcer and YAML validator

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -1,0 +1,22 @@
+name: "Enforce Changelog"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic'
+        missingUpdateErrorMessage: >
+            No update to CHANGELOG.md found! Please add a changelog
+            entry to it describing your change.  Please note that the
+            keepachangelog (https://keepachangelog.com) format is
+            used. If your change is very trivial not applicable for a
+            changelog entry, add a 'Skip Changelog' label to the pull
+            request to skip the changelog enforcer.
+

--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -1,0 +1,31 @@
+---
+
+# Based on code from https://github.com/marketplace/actions/yaml-lint
+
+name: Yaml Lint
+
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+# This validation is equivalent to running on the command line:
+#   yamllint -d relaxed --no-warnings
+# and is controlled by the .yamllint.yml file
+jobs:
+  validate-YAML:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: yaml-lint
+        name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          no_warnings: true
+          format: colored
+          config_file: .yamllint.yml
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: yamllint-logfile
+          path: ${{ steps.yaml-lint.outputs.logfile }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,29 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of QuickChem repository
+- Added changelog enforcer and yaml validator GitHub actions


### PR DESCRIPTION
As this repo has a CHANGELOG, we should add an enforcer.

I'm also adding in a YAML validator GitHub Action as well. This repo doesn't really have any YAML files yet, but it might in future, so this is future-proofing.