### PR TITLE
Optimization of OH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2022-00-00
 
+### Changed
+- Optimized OH by reducing the number of calls to XGBoost
+
 ### Added
 
 - Initial release of QuickChem repository
 - Added changelog enforcer and yaml validator GitHub actions
+- Added routine IS_QC_INSTANCE_RUNNING, to be called by the parent GridComp
+- Added OH flag compute_once_per_day, and support for RUNALARM

--- a/OH_GridComp/OH_instance_OH.rc
+++ b/OH_GridComp/OH_instance_OH.rc
@@ -19,10 +19,10 @@ XGBoost_0.81_File: /discover/nobackup/mmanyin/CCM/run/oh26/OH_model/OH_Tuned_M01
 XGBoost_1.6.0_File: /discover/nobackup/mmanyin/CCM/OH_Boost/XGBoost_1.6.0/xgboh_UpDwnALBUVSZAAll_NoGMIALB_NoScale_NoRegressor_NewXGB_M01.model
 XGBoostFile: /discover/nobackup/mmanyin/CCM/OH_Boost/XGBoost_1.6.0/xgboh_UpDwnALBUVSZAAll_NoGMIALB_NoScale_NoRegressor_NewXGB_M01.model
 
-#
 #  Options are  PRECOMPUTED, ONLINE_INST, ONLINE_AVG24
+#  If using ONLINE_AVG24, then you should set  compute_once_per_day = TRUE
 OH_data_source: ONLINE_AVG24
-#
+
 #  If true,  OH imports both the instantaneous and 24hr average fields for T, P, etc
 #            This allows for the use of instantaneous fields when tavg fields are all zero.
 #  If false, OH imports only the 24hr average fields; NOTE - they must be in the OH_import_rst
@@ -30,3 +30,9 @@ spinup_24hr_imports: T
 
 # For GOCART2G scattering coefficient, which wavelength to use
 wavelength_for_scacoef: 550
+
+#  If true, only compute w/ Boost during the first timestep of every day
+#           (best to use with ONLINE_AVG24 input)
+#  If false, compute at every timestep
+#           (good when input parameters change over the course of the day)
+compute_once_per_day: T


### PR DESCRIPTION
This PR speeds up OH dramatically. Instead of calling the XGBoost predictor once per gridbox, it calls the predictor once per timestep (covering the entire domain of interest in one call); because of the overhead involved in each Boost prediction, this results in significant speedup. And the user can easily run the routine less frequently, using OH_DT or a new flag for daily frequency. Thanks to @sstrode for identifying this issue, and thanks to Peter Ivatt, @christophkeller , @bena-nasa and @mathomp4 for assistance on this.

This PR is zero-diff with the previous version, when run using the same time resolution.
It currently requires the feature/mmanyin/QUICKCHEM_v1 branch for these repo's:
                GEOSgcm
                GEOSgcm_GridComp
                GEOSchem_GridComp
                GOCART
                GEOSgcm_App
