### PR TITLE
include Brown Carbon for AOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+### Removed
+
+## [1.1.0] - 2022-03-07
+
+### Added
 
 - Added a scaling factor to scale OH by a constant
 - Added exports for OH
+- Added NOTES.wiki, instructions on how to compile & use, a duplicate of the GitHub wiki for QuickChem;
+  this is to help us track how it changes over time
 
 ### Changed
 
 - Moved to GitHub Actions for label enforcement
 - Changed OH Boost file to be climatology rather than single month
+- Changed AOD calculation to include Brown Carbon scattering coefficient
 
-### Fixed
-
-### Removed
 
 ## [1.0.0] - 2022-07-26
 

--- a/NOTES.wiki
+++ b/NOTES.wiki
@@ -1,0 +1,82 @@
+How to check out and set up the latest version
+
+As of July 26, 2022  (with modification Feb 27, 2023)
+These commands will clone and build the most recent release of QuickChem:
+
+mkdir QUICKCHEM_2022-07-26
+cd QUICKCHEM_2022-07-26/
+git clone git@github.com:GEOS-ESM/GEOSgcm.git
+cd GEOSgcm/
+git checkout remotes/origin/feature/mmanyin/QUICKCHEM_v1
+mepo clone
+
+To gain access to the latest QuickChem features:
+pushd src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@QuickChem
+git checkout remotes/origin/main
+popd
+parallel_build.csh -mepo -walltime 00:50:00 -q debug -account s1043 -no-tar
+
+To set up an ECCOH experiment, first run gcm_setup.
+Be sure to ask for Cascade Lake nodes.
+
+If running with AMIP emissions,
+/bin/cp <sandbox>/install/etc/AMIP/Chem_Registry.rc RC/
+
+Then edit these 6 files:
+
+===== RC/Chem_Registry.rc
+
+doing_CH4: yes
+
+nbins_CH4: 1
+
+Add this as the first entry in variable_table_CH4:
+CH4 'mol mol-1' Methane
+
+===== gcm_run.j
+
+Change the SLURM constraint to be:
+#SBATCH --constraint="cssro&cas"
+
+Add this line before the section "Rename big ExtData files"
+/bin/ln -sf $EXPDIR/RC/Chem_Registry.rc .
+
+===== RC/GEOS_ChemGridComp.rc
+
+ENABLE_QUICKCHEM: .TRUE.
+
+optional:
+strict_child_timing: .TRUE.
+
+===== RC/OH_instance_OH.rc
+
+If OH_data_source is ONLINE_AVG24 and you don't have the 24-hr averages in oh_import_rst:
+
+spinup_24hr_imports: T
+
+Otherwise set it to F .
+
+===== AGCM.rc
+
+ADD THESE:
+# How often to run OH:
+OH_DT: 3600
+# Set this to the HEARTBEAT in order to run OH during the first timestep of each OH_DT interval:
+OH_REFERENCE_TIME: 000730
+
+UNCOMMENT THESE:
+OH_INTERNAL_RESTART_FILE: oh_internal_rst
+OH_INTERNAL_CHECKPOINT_FILE: oh_internal_checkpoint
+OH_INTERNAL_CHECKPOINT_TYPE: default
+
+OH_IMPORT_RESTART_FILE: oh_import_rst
+OH_IMPORT_CHECKPOINT_FILE: oh_import_checkpoint
+OH_IMPORT_CHECKPOINT_TYPE: default
+
+===== RC/OH_GridComp_ExtData.rc
+
+vi command:
+%s+/discover/nobackup/projects/gmao/merra2_gmi/pub+/css/merra2gmi/pub+
+
+===== ALSO you may want to edit HISTORY.rc to include fields such as 'GOCART::CH4' and 'GOCART::CO' from GOCART, and 'OH' from OH
+

--- a/NOTES.wiki
+++ b/NOTES.wiki
@@ -1,19 +1,13 @@
 How to check out and set up the latest version
 
-As of July 26, 2022  (with modification Feb 27, 2023)
-These commands will clone and build the most recent release of QuickChem:
-
-mkdir QUICKCHEM_2022-07-26
-cd QUICKCHEM_2022-07-26/
+As of March 6, 2023  
+These commands will clone and build the most recent release of QuickChem on NCCS discover:  
+  
+mkdir QUICKCHEM_2023-03-06  
+cd QUICKCHEM_2023-03-06/
 git clone git@github.com:GEOS-ESM/GEOSgcm.git
 cd GEOSgcm/
-git checkout remotes/origin/feature/mmanyin/QUICKCHEM_v1
-mepo clone
-
-To gain access to the latest QuickChem features:
-pushd src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@QuickChem
-git checkout remotes/origin/main
-popd
+git checkout remotes/origin/feature/mmanyin/QUICKCHEM_DEV
 parallel_build.csh -mepo -walltime 00:50:00 -q debug -account s1043 -no-tar
 
 To set up an ECCOH experiment, first run gcm_setup.
@@ -22,7 +16,7 @@ Be sure to ask for Cascade Lake nodes.
 If running with AMIP emissions,
 /bin/cp <sandbox>/install/etc/AMIP/Chem_Registry.rc RC/
 
-Then edit these 6 files:
+Then edit these 5 files:
 
 ===== RC/Chem_Registry.rc
 
@@ -73,10 +67,5 @@ OH_IMPORT_RESTART_FILE: oh_import_rst
 OH_IMPORT_CHECKPOINT_FILE: oh_import_checkpoint
 OH_IMPORT_CHECKPOINT_TYPE: default
 
-===== RC/OH_GridComp_ExtData.rc
-
-vi command:
-%s+/discover/nobackup/projects/gmao/merra2_gmi/pub+/css/merra2gmi/pub+
 
 ===== ALSO you may want to edit HISTORY.rc to include fields such as 'GOCART::CH4' and 'GOCART::CO' from GOCART, and 'OH' from OH
-

--- a/OH_GridComp/OH_GridCompMod.F90
+++ b/OH_GridComp/OH_GridCompMod.F90
@@ -719,6 +719,7 @@ contains
 
      ADD_IMPORT_NORST_4DC( 'BCSCACOEF',   'Black Carbon Scattering Coefficient [550 nm]', 'm-1' )
      ADD_IMPORT_NORST_4DC( 'OCSCACOEF', 'Organic Carbon Scattering Coefficient [550 nm]', 'm-1' )
+     ADD_IMPORT_NORST_4DC( 'BRSCACOEF',   'Brown Carbon Scattering Coefficient [550 nm]', 'm-1' )
      ADD_IMPORT_NORST_4DC( 'DUSCACOEF', '          Dust Scattering Coefficient [550 nm]', 'm-1' )
      ADD_IMPORT_NORST_4DC( 'SUSCACOEF', '           SO4 Scattering Coefficient [550 nm]', 'm-1' )
      ADD_IMPORT_NORST_4DC( 'SSSCACOEF',       'Sea Salt Scattering Coefficient [550 nm]', 'm-1' )
@@ -747,6 +748,7 @@ contains
 
      ADD_IMPORT_24_4DC( 'BCSCACOEF_avg24', 'daily_mean_Black_Carbon_Scattering_Coefficient_[550_nm]',   'm-1'     )
      ADD_IMPORT_24_4DC( 'OCSCACOEF_avg24', 'daily_mean_Organic_Carbon_Scattering_Coefficient_[550_nm]', 'm-1'     )
+     ADD_IMPORT_24_4DC( 'BRSCACOEF_avg24', 'daily_mean_Brown_Carbon_Scattering_Coefficient_[550_nm]',   'm-1'     )
      ADD_IMPORT_24_4DC( 'DUSCACOEF_avg24', 'daily_mean_Dust_Scattering_Coefficient_[550_nm]',           'm-1'     )
      ADD_IMPORT_24_4DC( 'SUSCACOEF_avg24', 'daily_mean_SO4_Scattering_Coefficient_[550_nm]',            'm-1'     )
      ADD_IMPORT_24_4DC( 'SSSCACOEF_avg24', 'daily_mean_Sea_Salt_Scattering_Coefficient_[550_nm]',       'm-1'     )
@@ -772,6 +774,7 @@ contains
      ! Archived SCACOEF fields are 3D
      ADD_IMPORT_NORST_3DC( 'oh_BCSCACOEF',   'Black Carbon Scattering Coefficient [550 nm]', 'm-1'     )
      ADD_IMPORT_NORST_3DC( 'oh_OCSCACOEF', 'Organic Carbon Scattering Coefficient [550 nm]', 'm-1'     )
+     ADD_IMPORT_NORST_3DC( 'oh_BRSCACOEF',   'Brown Carbon Scattering Coefficient [550 nm]', 'm-1'     )
      ADD_IMPORT_NORST_3DC( 'oh_DUSCACOEF',           'Dust Scattering Coefficient [550 nm]', 'm-1'     )
      ADD_IMPORT_NORST_3DC( 'oh_SUSCACOEF',            'SO4 Scattering Coefficient [550 nm]', 'm-1'     )
      ADD_IMPORT_NORST_3DC( 'oh_SSSCACOEF',       'Sea Salt Scattering Coefficient [550 nm]', 'm-1'     )
@@ -1050,6 +1053,7 @@ contains
       ! from original GOCART
       REAL, POINTER, DIMENSION(:,:,:)   ::  BCscacoef_3D  => null()
       REAL, POINTER, DIMENSION(:,:,:)   ::  OCscacoef_3D  => null()
+      REAL, POINTER, DIMENSION(:,:,:)   ::  BRscacoef_3D  => null()
       REAL, POINTER, DIMENSION(:,:,:)   ::  DUscacoef_3D  => null()
       REAL, POINTER, DIMENSION(:,:,:)   ::  SUscacoef_3D  => null()
       REAL, POINTER, DIMENSION(:,:,:)   ::  SSscacoef_3D  => null()
@@ -1058,6 +1062,7 @@ contains
       ! from GOCART2G
       REAL, POINTER, DIMENSION(:,:,:,:) ::  BCscacoef_4D  => null()
       REAL, POINTER, DIMENSION(:,:,:,:) ::  OCscacoef_4D  => null()
+      REAL, POINTER, DIMENSION(:,:,:,:) ::  BRscacoef_4D  => null()
       REAL, POINTER, DIMENSION(:,:,:,:) ::  DUscacoef_4D  => null()
       REAL, POINTER, DIMENSION(:,:,:,:) ::  SUscacoef_4D  => null()
       REAL, POINTER, DIMENSION(:,:,:,:) ::  SSscacoef_4D  => null()
@@ -1394,6 +1399,14 @@ contains
            if ( .NOT. self%use_inst_values )     CALL MAPL_GetPointer(import, OCscacoef_4D,     'OCSCACOEF_avg24', __RC__ )
       endif
 
+      if ( self%OH_data_source == PRECOMPUTED  ) CALL MAPL_GetPointer(import, BRscacoef_3D,  'oh_BRSCACOEF',       __RC__ )
+      if ( self%OH_data_source == ONLINE_INST  ) CALL MAPL_GetPointer(import, BRscacoef_4D,     'BRSCACOEF',       __RC__ )
+      if ( self%OH_data_source == ONLINE_AVG24 ) then
+           if (       self%use_inst_values )     CALL MAPL_GetPointer(import, BRscacoef_4D,     'BRSCACOEF',       __RC__ )
+           if ( .NOT. self%use_inst_values )     CALL MAPL_GetPointer(import, BRscacoef_4D,     'BRSCACOEF_avg24', __RC__ )
+      endif
+
+
       if ( self%OH_data_source == PRECOMPUTED  ) CALL MAPL_GetPointer(import, DUscacoef_3D,  'oh_DUSCACOEF',       __RC__ )
       if ( self%OH_data_source == ONLINE_INST  ) CALL MAPL_GetPointer(import, DUscacoef_4D,     'DUSCACOEF',       __RC__ )
       if ( self%OH_data_source == ONLINE_AVG24 ) then
@@ -1440,11 +1453,12 @@ contains
    !  Aerosol Optical Depth
    !  ---------------------
       IF ( self%OH_data_source == PRECOMPUTED  ) THEN
-        aod = gridBoxThickness * ( BCscacoef_3D + OCscacoef_3D + DUscacoef_3D + &
+        aod = gridBoxThickness * ( BCscacoef_3D + OCscacoef_3D + BRscacoef_3D + DUscacoef_3D + &
                                    SUscacoef_3D + SSscacoef_3D + NIscacoef_3D )
       ELSE
         aod = gridBoxThickness * ( BCscacoef_4D(:,:,:,self%wavelength_index) + &
                                    OCscacoef_4D(:,:,:,self%wavelength_index) + &
+                                   BRscacoef_4D(:,:,:,self%wavelength_index) + &
                                    DUscacoef_4D(:,:,:,self%wavelength_index) + &
                                    SUscacoef_4D(:,:,:,self%wavelength_index) + &
                                    SSscacoef_4D(:,:,:,self%wavelength_index) + &
@@ -1670,6 +1684,14 @@ contains
           ptr3d(:,:,:) =     OCscacoef_3D
         ELSE
           ptr3d(:,:,:) =     OCscacoef_4D(:,:,:,self%wavelength_index)
+        ENDIF
+      ENDIF
+      CALL MAPL_GetPointer(export, ptr3d, 'DIAG_SC_BR',       __RC__)
+      IF (ASSOCIATED(ptr3d)) THEN
+        IF ( self%OH_data_source == PRECOMPUTED ) THEN
+          ptr3d(:,:,:) =     BRscacoef_3D
+        ELSE
+          ptr3d(:,:,:) =     BRscacoef_4D(:,:,:,self%wavelength_index)
         ENDIF
       ENDIF
       CALL MAPL_GetPointer(export, ptr3d, 'DIAG_SC_DU',       __RC__)

--- a/OH_GridComp/OH_GridComp_ExtData.rc
+++ b/OH_GridComp/OH_GridComp_ExtData.rc
@@ -18,43 +18,43 @@ climxx001           'kg kg-1'            Y        N               0             
 #
 # 3D
 #
-oh_NO2          mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    NO2           /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_ALK4         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    ALK4          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_ISOP         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    ISOP          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_ACET         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    ACET          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_PRPE         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    PRPE          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_C3H8         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    C3H8          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_C2H6         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    C2H6          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_O3           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    O3            /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_CO           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    CO            /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_CH4          mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    CH4           /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_MP           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    MP            /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_H2O2         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    H2O2          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_CH2O         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    CH2O          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
-oh_GMITO3       mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    GMITO3        /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_2d_dad_Nx.%y4%m2%d2.nc4
-oh_GMITTO3      mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    GMITTO3       /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_2d_dad_Nx.%y4%m2%d2.nc4
-oh_OH           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    OH            /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_NO2          mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    NO2           /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_ALK4         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    ALK4          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_ISOP         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    ISOP          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_ACET         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    ACET          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_PRPE         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    PRPE          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_C3H8         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    C3H8          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_C2H6         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    C2H6          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_O3           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    O3            /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_CO           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    CO            /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_CH4          mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    CH4           /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_MP           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    MP            /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_H2O2         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    H2O2          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_CH2O         mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    CH2O          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
+oh_GMITO3       mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    GMITO3        /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_2d_dad_Nx.%y4%m2%d2.nc4
+oh_GMITTO3      mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    GMITTO3       /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_2d_dad_Nx.%y4%m2%d2.nc4
+oh_OH           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none    OH            /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_dac_Nv.%y4%m2%d2.nc4
 # in case the GOCART modules are not running:
-oh_BCSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    BCSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
-oh_OCSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    OCSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_BCSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    BCSCACOEF    /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_OCSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    OCSCACOEF    /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
 oh_BRSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    BRSCACOEF    /dev/null
-oh_DUSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    DUSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
-oh_SUSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    SUSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
-oh_SSSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    SSSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
-oh_NISCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    NISCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_DUSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    DUSCACOEF    /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_SUSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    SUSCACOEF    /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_SSSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    SSSCACOEF    /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_NISCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    NISCACOEF    /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
 #
 # 3-hourly, interp every timestep:
 #
-oh_T           K     N   Y            0              none     none    T            /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_met_Nv.%y4%m2%d2.nc4
-oh_Q           Pa    N   Y            0              none     none    QV           /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_met_Nv.%y4%m2%d2.nc4
-oh_TAUCLW      1     N   Y            0              none     none    TAUCLW       /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_cld_Nv.%y4%m2%d2.nc4
-oh_TAUCLI      1     N   Y            0              none     none    TAUCLI       /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_cld_Nv.%y4%m2%d2.nc4
-oh_FCLD        1     N   Y            0              none     none    CLOUD        /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_cld_Nv.%y4%m2%d2.nc4
-oh_PLE         Pa    N   Y            0              none     none    PLE          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_mst_Ne.%y4%m2%d2.nc4
-oh_ZLE         m     N   Y            0              none     none    ZLE          /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_mst_Ne.%y4%m2%d2.nc4
+oh_T           K     N   Y            0              none     none    T            /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_met_Nv.%y4%m2%d2.nc4
+oh_Q           Pa    N   Y            0              none     none    QV           /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_met_Nv.%y4%m2%d2.nc4
+oh_TAUCLW      1     N   Y            0              none     none    TAUCLW       /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_cld_Nv.%y4%m2%d2.nc4
+oh_TAUCLI      1     N   Y            0              none     none    TAUCLI       /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_cld_Nv.%y4%m2%d2.nc4
+oh_FCLD        1     N   Y            0              none     none    CLOUD        /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_cld_Nv.%y4%m2%d2.nc4
+oh_PLE         Pa    N   Y            0              none     none    PLE          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_mst_Ne.%y4%m2%d2.nc4
+oh_ZLE         m     N   Y            0              none     none    ZLE          /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg3_3d_mst_Ne.%y4%m2%d2.nc4
 #
 # 2D
 #
 oh_ALBUV   transmittance   Y        Y     %y4-%m2-%d2t12:00:00    none     none    LER           /discover/nobackup/mmanyin/CCM/OH/OMILER_345nm_climo_x576_y361_t12.nc4
-oh_TROPP        Pa         N        N     %y4-%m2-%d2t12:00:00    none     none    TROPPB        /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_2d_dad_Nx.%y4%m2%d2.nc4
+oh_TROPP        Pa         N        N     %y4-%m2-%d2t12:00:00    none     none    TROPPB        /css/merra2gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_2d_dad_Nx.%y4%m2%d2.nc4
 %%

--- a/OH_GridComp/OH_GridComp_ExtData.rc
+++ b/OH_GridComp/OH_GridComp_ExtData.rc
@@ -37,6 +37,7 @@ oh_OH           mol/mol    N        Y     %y4-%m2-%d2t12:00:00    none     none 
 # in case the GOCART modules are not running:
 oh_BCSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    BCSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
 oh_OCSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    OCSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
+oh_BRSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    BRSCACOEF    /dev/null
 oh_DUSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    DUSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
 oh_SUSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    SUSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4
 oh_SSSCACOEF   m-1   N   Y   %y4-%m2-%d2t12:00:00    none     none    SSSCACOEF    /discover/nobackup/projects/gmao/merra2_gmi/pub/Y%y4/M%m2/MERRA2_GMI.tavg24_3d_adf_Nv.%y4%m2%d2.nc4

--- a/OH_GridComp/OH_StateSpecs.rc
+++ b/OH_GridComp/OH_StateSpecs.rc
@@ -60,6 +60,7 @@ category: EXPORT
  DIAG_OH_M2G     | ???     | xyz  | C    |           | Diagnostic of OH
  DIAG_SC_BC      | ???     | xyz  | C    |           | Diagnostic of SCACOEF for BC
  DIAG_SC_OC      | ???     | xyz  | C    |           | Diagnostic of SCACOEF for OC
+ DIAG_SC_BR      | ???     | xyz  | C    |           | Diagnostic of SCACOEF for BR
  DIAG_SC_DU      | ???     | xyz  | C    |           | Diagnostic of SCACOEF for DU
  DIAG_SC_SU      | ???     | xyz  | C    |           | Diagnostic of SCACOEF for SU
  DIAG_SC_SS      | ???     | xyz  | C    |           | Diagnostic of SCACOEF for SS


### PR DESCRIPTION
This PR is non-zero-diff for OH.
It is intended to complete v1.1.0 .
It depends on the following other repositories:
GEOSgcm: 6866df080aa0734737ea5a7d1d4985a67bb9f363
GEOSgcm_GridComp: fbc9b5ca145fbc163eec32bd3c82e68994f38c84
GEOSchem_GridComp: 916c59b9b9a366a6094ec077a4de4f5d6187605e
GOCART: 6e237a8ed45f742a5a68695e0e8180aa096ad188
GEOSgcm_App: 839a2696dc15592bb16fba22c9f0313b4579acaf

Additions:
- Added NOTES.wiki, instructions on how to compile & use, a duplicate of the GitHub wiki for QuickChem;
  this is to help us track how it changes over time
Changes:
- Changed AOD calculation to include Brown Carbon scattering coefficient
- MERRA2-GMI output files have been relocated to /css